### PR TITLE
feat: Go to next event directly after choice

### DIFF
--- a/animations.css
+++ b/animations.css
@@ -5,6 +5,10 @@
 }
 
 /* Animation for floating resource numbers */
+.resource {
+    position: relative;
+}
+
 .resource-feedback {
     position: absolute;
     bottom: 20px;

--- a/script.js
+++ b/script.js
@@ -227,10 +227,10 @@ class GameState {
             }
         });
 
-        // Show continue button after a brief delay
+        // Go to next event after a brief delay
         setTimeout(() => {
-            this.showContinueButton();
-        }, 1000);
+            this.nextEvent();
+        }, 2000);
     }
 
     // Show floating resource change feedback
@@ -251,12 +251,6 @@ class GameState {
                 feedback.parentNode.removeChild(feedback);
             }
         }, 2000);
-    }
-
-    // Show continue button
-    showContinueButton() {
-        const choicesContainer = document.getElementById('choices-container');
-        choicesContainer.innerHTML = '<button onclick="game.nextEvent()" class="choice-btn continue-btn">Continue</button>';
     }
 
     // Advance to next event


### PR DESCRIPTION
This commit streamlines the gameplay by removing the 'Continue' button and proceeding to the next event automatically after you make a choice.

- The `makeChoice` function in `script.js` now calls `nextEvent` after a delay to allow animations to play.
- The `showContinueButton` function has been removed from `script.js`.
- The `animations.css` file has been updated to ensure the floating resource numbers originate from the correct resource bars.